### PR TITLE
fix: Failing Redirect on VDS

### DIFF
--- a/manual-configuration-files/default.conf
+++ b/manual-configuration-files/default.conf
@@ -4,8 +4,7 @@ server {
     index index.html;
     #root /var/www/sites/static/domain-name;
 
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
-        expires max;
-        log_not_found off;
+    location / {
+        try_files $uri $uri/ /index.html?$args;
     }
 }


### PR DESCRIPTION
Avval [example.com/about](url) manziliga kirilganida
**404 Not Found
nginx/1.25.1**
yozuvlari chiqqan edi.

Bu o'zgarishdan keyin to'g'ri ishlay boshladi.